### PR TITLE
Integrate active admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "bootstrap-sass"
 gem "font-awesome-sass"
 gem "bourbon"
 gem "simple_form"
+gem "activeadmin", "~> 1.0.0.pre1"
 
 gem "mailgunner"
 gem "devise"

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "devise"
 
 gem "draper"
 
-
 group :doc do
   gem "sdoc", "~> 0.4.0", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "simple_form"
 gem "mailgunner"
 gem "devise"
 
+gem "draper"
+
 group :doc do
   gem "sdoc", "~> 0.4.0", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "haml"
 gem "bootstrap-sass"
 gem "font-awesome-sass"
 gem "bourbon"
+gem "jquery-datetimepicker-rails"
 gem "simple_form"
 gem "activeadmin", "~> 1.0.0.pre1"
 
@@ -22,6 +23,7 @@ gem "mailgunner"
 gem "devise"
 
 gem "draper"
+
 
 group :doc do
   gem "sdoc", "~> 0.4.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     jbuilder (2.2.12)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
+    jquery-datetimepicker-rails (2.4.1.0)
     jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -341,6 +342,7 @@ DEPENDENCIES
   guard-rspec
   haml
   jbuilder (~> 2.0)
+  jquery-datetimepicker-rails
   jquery-rails
   launchy
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,19 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    activeadmin (1.0.0.pre1)
+      arbre (~> 1.0, >= 1.0.2)
+      bourbon
+      coffee-rails
+      formtastic (~> 3.1)
+      formtastic_i18n
+      inherited_resources (~> 1.6)
+      jquery-rails
+      jquery-ui-rails (~> 5.0)
+      kaminari (~> 0.15)
+      rails (>= 3.2, < 5.0)
+      ransack (~> 1.3)
+      sass-rails
     activejob (4.2.0)
       activesupport (= 4.2.0)
       globalid (>= 0.3.0)
@@ -37,6 +50,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    arbre (1.0.3)
+      activesupport (>= 3.0.0)
     arel (6.0.0)
     autoprefixer-rails (5.1.8.1)
       execjs
@@ -99,6 +114,9 @@ GEM
     font-awesome-sass (4.3.2.1)
       sass (~> 3.2)
     formatador (0.2.5)
+    formtastic (3.1.3)
+      actionpack (>= 3.2.13)
+    formtastic_i18n (0.3.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     guard (2.12.5)
@@ -121,10 +139,18 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     haml (4.0.6)
       tilt
+    has_scope (0.6.0)
+      actionpack (>= 3.2, < 5)
+      activesupport (>= 3.2, < 5)
     hike (1.2.3)
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    inherited_resources (1.6.0)
+      actionpack (>= 3.2, < 5)
+      has_scope (~> 0.6.0.rc)
+      railties (>= 3.2, < 5)
+      responders
     jbuilder (2.2.12)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -132,7 +158,12 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.3)
+      railties (>= 3.2.16)
     json (1.8.2)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.3.0)
@@ -165,6 +196,8 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    polyamorous (1.2.0)
+      activerecord (>= 3.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -201,6 +234,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
+    ransack (1.6.6)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -286,6 +325,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activeadmin (~> 1.0.0.pre1)
   bootstrap-sass
   bourbon
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,11 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    draper (2.1.0)
+      actionpack (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      request_store (~> 1.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -200,6 +205,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rdoc (4.2.0)
+    request_store (1.1.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rspec (3.2.0)
@@ -287,6 +293,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise
+  draper
   fabrication
   faker
   font-awesome-sass

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,0 +1,33 @@
+ActiveAdmin.register_page "Dashboard" do
+
+  menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
+
+  content title: proc{ I18n.t("active_admin.dashboard") } do
+    div class: "blank_slate_container", id: "dashboard_default_message" do
+      span class: "blank_slate" do
+        span I18n.t("active_admin.dashboard_welcome.welcome")
+        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+      end
+    end
+
+    # Here is an example of a simple dashboard with columns and panels.
+    #
+    # columns do
+    #   column do
+    #     panel "Recent Posts" do
+    #       ul do
+    #         Post.recent(5).map do |post|
+    #           li link_to(post.title, admin_post_path(post))
+    #         end
+    #       end
+    #     end
+    #   end
+
+    #   column do
+    #     panel "Info" do
+    #       para "Welcome to ActiveAdmin."
+    #     end
+    #   end
+    # end
+  end # content
+end

--- a/app/admin/instructor.rb
+++ b/app/admin/instructor.rb
@@ -1,0 +1,34 @@
+ActiveAdmin.register Instructor do
+  permit_params :name
+
+  index do
+    id_column
+    column :name
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+    end
+
+    panel Instructor.human_attribute_name(:terms) do
+      table_for instructor.terms.decorate do
+        column :id
+        column Term.human_attribute_name(:subject), :subject
+        column Term.human_attribute_name(:starts_at), :starts_at
+        column Term.human_attribute_name(:ends_at), :ends_at
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :name
+      f.input :terms
+    end
+    f.actions
+  end
+end

--- a/app/admin/offer.rb
+++ b/app/admin/offer.rb
@@ -1,0 +1,43 @@
+ActiveAdmin.register Offer do
+  decorate_with OfferDecorator
+  permit_params :assignation_id, demands_attributes: [:term_id]
+
+  index do
+    id_column
+    column :user
+    column :term
+    column :status
+    column :created_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :user
+      row :term
+      row :status
+      row :created_at
+      row :updated_at
+    end
+
+    panel Offer.human_attribute_name(:demands) do
+      table_for offer.demands do
+        column Demand.human_attribute_name(:term) do |demand|
+          demand.term.display_name
+        end
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :assignation
+      f.has_many :demands, allow_destroy: true, new_record: true do |demand|
+        demand.inputs :term
+      end
+    end
+    f.actions
+  end
+end

--- a/app/admin/role.rb
+++ b/app/admin/role.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Role do
+  permit_params :name
+
+  index do
+    id_column
+    column :name
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+    end
+
+    panel :users do
+      table_for group.users do
+        column :id
+        column :username do |user|
+          link_to user.username, admin_user_path(user)
+        end
+        column :student_number
+        column :email
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :name
+    end
+    f.actions
+  end
+end

--- a/app/admin/schedule.rb
+++ b/app/admin/schedule.rb
@@ -1,0 +1,42 @@
+ActiveAdmin.register Schedule do
+  permit_params :user_id, term_ids: []
+  actions :all
+
+  index do
+    id_column
+    column :user
+    column :created_at
+    column :updated_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :user
+      row :created_at
+      row :updated_at
+    end
+
+    panel Schedule.human_attribute_name(:terms) do
+      table_for schedule.terms.decorate do
+        column :id do |term|
+          link_to term.id, admin_term_path(term)
+        end
+        column Term.human_attribute_name(:instructor), :instructor
+        column Term.human_attribute_name(:subject), :subject
+        column Term.human_attribute_name(:starts_at), :starts_at
+        column Term.human_attribute_name(:ends_at), :ends_at
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :user
+      f.input :terms, label_method: ->(term) { binding.pry; term.decorate.display_name }
+    end
+    f.actions
+  end
+end

--- a/app/admin/schedule.rb
+++ b/app/admin/schedule.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register Schedule do
     f.semantic_errors
     f.inputs do
       f.input :user
-      f.input :terms, label_method: ->(term) { binding.pry; term.decorate.display_name }
+      f.input :terms
     end
     f.actions
   end

--- a/app/admin/subject.rb
+++ b/app/admin/subject.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Subject do
+  permit_params :name
+
+  index do
+    id_column
+    column :name
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+    end
+
+    panel Subject.human_attribute_name(:terms) do
+      table_for subject.terms.decorate do
+        column :id do |term|
+          link_to term.id, admin_term_path(term)
+        end
+        column Term.human_attribute_name(:instructor), :instructor
+        column Term.human_attribute_name(:starts_at), :starts_at
+        column Term.human_attribute_name(:ends_at), :ends_at
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :name
+    end
+    f.actions
+  end
+end

--- a/app/admin/term.rb
+++ b/app/admin/term.rb
@@ -1,0 +1,36 @@
+ActiveAdmin.register Term do
+  decorate_with TermDecorator
+  permit_params :subject_id, :instructor_id, :description, :starts_at, :ends_at
+
+  index do
+    id_column
+    column :subject
+    column :instructor
+    column :description
+    column :starts_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :subject
+      row :instructor
+      row :description
+      row :starts_at
+      row :ends_at
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :subject
+      f.input :instructor
+      f.input :description
+      f.input :starts_at, as: :string, input_html: { class: "datetime_picker" }
+      f.input :ends_at, as: :string, input_html: { class: "datetime_picker" }
+    end
+    f.actions
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,0 +1,51 @@
+ActiveAdmin.register User do
+  permit_params :username, :student_number, :email, group_ids: []
+  actions :all, except: [:new, :create]
+
+  index do
+    id_column
+    column :username
+    column :student_number
+    column :email
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :username
+      row :student_number
+      row :email
+      row :created_at
+      row :updated_at
+      row :confirmed_at
+    end
+
+    panel User.human_attribute_name(:groups) do
+      table_for user.groups do
+        column :id
+        column :name
+      end
+    end
+
+    panel User.human_attribute_name(:schedules) do
+      table_for user.schedules do
+        column :id do |schedule|
+          link_to schedule.id, admin_schedule_path(schedule)
+        end
+        column Schedule.human_attribute_name(:created_at)
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :username
+      f.input :student_number
+      f.input :email
+      f.input :groups
+    end
+    f.actions
+  end
+end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,0 +1,1 @@
+#= require active_admin/base

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,3 @@
 #= require active_admin/base
+#= require jquery.datetimepicker
+#= require active_admin_datepicker_init.js

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -1,0 +1,17 @@
+// SASS variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.css.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "active_admin/mixins";
+@import "active_admin/base";
+
+// Overriding any non-variable SASS must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -1,3 +1,4 @@
+//= require jquery.datetimepicker
 // SASS variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at
@@ -11,7 +12,12 @@
 @import "active_admin/mixins";
 @import "active_admin/base";
 
+
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }
+
+.xdsoft_time.xdsoft_disabled {
+  display: none;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,9 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up).push %i(username student_number)
   end
+
+  def authenticate_admin_user!
+    redirect_to new_user_session_path and return unless current_user.present?
+    redirect_to root_path, flash: { error: I18n.t(".access_denied") } unless current_user.admin?
+  end
 end

--- a/app/decorators/assignation_decorator.rb
+++ b/app/decorators/assignation_decorator.rb
@@ -1,0 +1,7 @@
+class AssignationDecorator < Draper::Decorator
+  delegate_all
+
+  def display_name
+    "#{object.schedule.user.username}: #{object.term.display_name}"
+  end
+end

--- a/app/decorators/offer_decorator.rb
+++ b/app/decorators/offer_decorator.rb
@@ -1,0 +1,23 @@
+class OfferDecorator < Draper::Decorator
+  delegate_all
+
+  def display_name
+    assignation.display_name
+  end
+
+  def user
+    assignation.schedule.user
+  end
+
+  def assignation
+    object.assignation.decorate
+  end
+
+  def subject
+    term.subject
+  end
+
+  def term
+    object.assignation.term.decorate
+  end
+end

--- a/app/decorators/term_decorator.rb
+++ b/app/decorators/term_decorator.rb
@@ -1,0 +1,15 @@
+class TermDecorator < Draper::Decorator
+  delegate_all
+
+  def display_name
+    "#{object.subject.name}: #{starts_at} - #{ends_at}"
+  end
+
+  def starts_at
+    I18n.l(object.starts_at, format: "%A, %H:%M")
+  end
+
+  def ends_at
+    I18n.l(object.ends_at, format: "%A, %H:%M")
+  end
+end

--- a/app/models/assignation.rb
+++ b/app/models/assignation.rb
@@ -3,4 +3,8 @@ class Assignation < ActiveRecord::Base
   belongs_to :term
 
   validates :schedule, :term, presence: true
+
+  def display_name
+    decorate.display_name
+  end
 end

--- a/app/models/demand.rb
+++ b/app/models/demand.rb
@@ -1,0 +1,6 @@
+class Demand < ActiveRecord::Base
+  belongs_to :offer, inverse_of: :demands
+  belongs_to :term
+
+  validates :offer, :term, presence: true
+end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,0 +1,10 @@
+class Offer < ActiveRecord::Base
+  belongs_to :assignation
+  has_many   :demands, inverse_of: :offer
+
+  accepts_nested_attributes_for :demands, allow_destroy: true
+
+  validates :assignation, :demands, presence: true
+
+  enum status: { active: 0, accepted: 1, withdrawn: 2 }
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,6 @@
+class Role < ActiveRecord::Base
+  has_many :user_roles
+  has_many :users, through: :user_roles
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -9,4 +9,8 @@ class Term < ActiveRecord::Base
   validates :starts_at, date: { before: :ends_at }
   validates :starts_at, uniqueness: { scope: [:subject_id, :instructor_id] }
   validates :description, length: { maximum: 100 }
+
+  def display_name
+    decorate.display_name
+  end
 end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -6,7 +6,7 @@ class Term < ActiveRecord::Base
   belongs_to :instructor
 
   validates :subject, :instructor, :starts_at, :ends_at, presence: true
-  validates :starts_at,  date: { before: :ends_at }
+  validates :starts_at, date: { before: :ends_at }
   validates :starts_at, uniqueness: { scope: [:subject_id, :instructor_id] }
   validates :description, length: { maximum: 100 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,13 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :confirmable, :validatable
 
   has_many :schedules
+  has_many :user_roles
+  has_many :roles, through: :user_roles
 
   validates :username, :student_number, presence: true, uniqueness: true
   validates :student_number, format: { with: /\A\d{6}\Z/, message: :format_message }
+
+  def admin?
+    roles.any? { |role| role.name.include? "Admin" }
+  end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,0 +1,6 @@
+class UserRole < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :role
+
+  validates :user, :role, presence: true
+end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -19,6 +19,8 @@
           .navbar-btn
             - if current_user.present?
               = link_to t("layout.header.sign_out"), destroy_user_session_path, method: :delete, class: "btn btn-default"
+              - if current_user.admin?
+                = link_to t("layout.header.admin_panel"), admin_root_path, class: "btn btn-primary", data: { no_turbolink: true }
             - else
               = link_to t("layout.header.sign_in"), new_user_session_path, class: "btn btn-default"
               = link_to t("layout.header.sign_up"), new_user_registration_path, class: "btn btn-primary"

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,233 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = "Exchange"
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  config.authentication_method = :authenticate_admin_user!
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+  config.current_user_method = :current_user
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  config.logout_link_path = :destroy_user_session_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  config.logout_link_method = :delete
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  # config.root_to = 'dashboard#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  config.comments = false
+  #
+  # You can disable the menu item for the comments index page:
+  # config.show_comments_in_menu = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_filter :do_something_awesome
+
+  # == Setting a Favicon
+  #
+  # config.favicon = 'favicon.ico'
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  config.namespace :admin do |admin|
+    admin.build_menu :utility_navigation do |menu|
+      menu.add label: I18n.t(".basic_view"), url: "/", html_options: { target: :blank }
+      admin.add_logout_button_to_menu menu
+    end
+  end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+end

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -64,10 +64,17 @@ pl:
               confirmation: jest niepoprawne
             confirmation_token:
               <<: *general_errors_m
+        role:
+          attributes:
+            name:
+              <<: *general_errors_f
     models:
       user:
         one: Użytkownik
         other: Użytkownicy
+      role:
+        one: Rola
+        other: Role
     attributes:
       user:
         username: Login
@@ -78,3 +85,5 @@ pl:
         student_number: Numer albumu
         remember_me: Zapamiętaj hasło
         confirmation_token: Token potwierdzenia
+      role:
+        name: Nazwa

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -78,6 +78,9 @@ pl:
       role:
         one: Rola
         other: Role
+      schedule:
+        one: Plan zajęć
+        other: Plany zajęć
     attributes:
       user:
         username: Login
@@ -88,5 +91,7 @@ pl:
         student_number: Numer albumu
         remember_me: Zapamiętaj hasło
         confirmation_token: Token potwierdzenia
+        roles: Role
+        schedules: Plany zajęć
       role:
         name: Nazwa

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -94,6 +94,12 @@ pl:
       term:
         one: Termin zajęć
         other: Terminy zajęć
+      offer:
+        one: Oferta
+        other: Oferty
+      demand:
+        one: Żądanie
+        other: Żądania
     attributes:
       common_attributes: &common_attributes
         id: ID
@@ -130,3 +136,12 @@ pl:
         <<: *common_attributes
         terms: Zajęcia
         user: Właściciel
+      offer:
+        <<: *common_attributes
+        assignation: Obecny termin
+        status: Stan
+        term: Termin zajęć
+        user: Obecny właściciel
+        demands: Żądania
+      demand:
+        term: Termin

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,4 +1,6 @@
 pl:
+  access_denied: Nie masz odpowiednich uprawnień
+  basic_view: Widok podstawowy
   common:
     confirm: Czy jesteś pewien?
   layout:
@@ -6,6 +8,7 @@ pl:
       sign_in: "Zaloguj się"
       sign_up: "Rejestracja"
       sign_out: "Wyloguj"
+      admin_panel: "Panel admina"
     footer:
       contact_us: "Kontakt"
   home:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -71,6 +71,10 @@ pl:
           attributes:
             name:
               <<: *general_errors_f
+        subject:
+          attributes:
+            name:
+              <<: *general_errors_f
     models:
       user:
         one: Użytkownik
@@ -81,8 +85,23 @@ pl:
       schedule:
         one: Plan zajęć
         other: Plany zajęć
+      subject:
+        one: Przedmiot
+        other: Przedmioty
+      instructor:
+        one: Prowadzący
+        other: Prowadzący
+      term:
+        one: Termin zajęć
+        other: Terminy zajęć
     attributes:
+      common_attributes: &common_attributes
+        id: ID
+        name: Nazwa
+        created_at: Data utworzenia
+        updated_at: Data aktualizacji
       user:
+        <<: *common_attributes
         username: Login
         email: Email
         password: Hasło
@@ -94,4 +113,20 @@ pl:
         roles: Role
         schedules: Plany zajęć
       role:
-        name: Nazwa
+        <<: *common_attributes
+      subject:
+        <<: *common_attributes
+        terms: Terminy zajęć
+      term:
+        <<: *common_attributes
+        instructor: Prowadzący
+        subject: Przedmiot
+        starts_at: Godzina rozpoczęcia
+        ends_at: Godzina zakończenia
+      instructor:
+        <<: *common_attributes
+        terms: Prowadzone zajęcia
+      schedule:
+        <<: *common_attributes
+        terms: Zajęcia
+        user: Właściciel

--- a/config/locales/shared.pl.yml
+++ b/config/locales/shared.pl.yml
@@ -1,0 +1,13 @@
+pl:
+  time:
+    formats:
+      long: "%Y-%m-%d %H:%M:%S"
+  date:
+    day_names:
+      0: Niedziela
+      1: Poniedziałek
+      2: Wtorek
+      3: Środa
+      4: Czwartek
+      5: Piątek
+      6: Sobota

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  ActiveAdmin.routes(self)
   root 'home#home'
   devise_for :users
 end

--- a/db/migrate/20150422210810_create_roles.rb
+++ b/db/migrate/20150422210810_create_roles.rb
@@ -1,0 +1,7 @@
+class CreateRoles < ActiveRecord::Migration
+  def change
+    create_table :roles do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20150422210827_create_user_roles.rb
+++ b/db/migrate/20150422210827_create_user_roles.rb
@@ -1,0 +1,9 @@
+class CreateUserRoles < ActiveRecord::Migration
+  def change
+    create_table :user_roles do |t|
+      t.references :user, index: true
+      t.references :role, index: true
+    end
+    add_foreign_key :user_roles, :users
+  end
+end

--- a/db/migrate/20150422215049_create_active_admin_comments.rb
+++ b/db/migrate/20150422215049_create_active_admin_comments.rb
@@ -1,0 +1,19 @@
+class CreateActiveAdminComments < ActiveRecord::Migration
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.string :resource_id,   null: false
+      t.string :resource_type, null: false
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+    add_index :active_admin_comments, [:author_type, :author_id]
+    add_index :active_admin_comments, [:resource_type, :resource_id]
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/migrate/20150423223836_create_offers_and_demands.rb
+++ b/db/migrate/20150423223836_create_offers_and_demands.rb
@@ -1,0 +1,20 @@
+class CreateOffersAndDemands < ActiveRecord::Migration
+  def change
+    create_table :offers do |t|
+      t.references :assignation, index: true
+      t.integer    :status,      index: true, default: 0
+
+      t.timestamps
+    end
+
+    add_foreign_key :offers, :assignations
+
+    create_table :demands do |t|
+      t.references :offer, index: true
+      t.belongs_to :term,  index: true
+    end
+
+    add_foreign_key :demands, :offers
+    add_foreign_key :demands, :terms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,10 @@ ActiveRecord::Schema.define(version: 20150423212250) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
   create_table "schedules", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -60,6 +64,14 @@ ActiveRecord::Schema.define(version: 20150423212250) do
   add_index "terms", ["starts_at", "subject_id", "instructor_id"], name: "index_terms_on_starts_at_and_subject_id_and_instructor_id", unique: true, using: :btree
   add_index "terms", ["subject_id"], name: "index_terms_on_subject_id", using: :btree
 
+  create_table "user_roles", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "role_id"
+  end
+
+  add_index "user_roles", ["role_id"], name: "index_user_roles_on_role_id", using: :btree
+  add_index "user_roles", ["user_id"], name: "index_user_roles_on_user_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "username",                            null: false
     t.string   "student_number"
@@ -82,4 +94,5 @@ ActiveRecord::Schema.define(version: 20150423212250) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "schedules", "users"
+  add_foreign_key "user_roles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423212250) do
+ActiveRecord::Schema.define(version: 20150423223836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,11 +41,29 @@ ActiveRecord::Schema.define(version: 20150423212250) do
   add_index "assignations", ["schedule_id"], name: "index_assignations_on_schedule_id", using: :btree
   add_index "assignations", ["term_id"], name: "index_assignations_on_term_id", using: :btree
 
+  create_table "demands", force: :cascade do |t|
+    t.integer "offer_id"
+    t.integer "term_id"
+  end
+
+  add_index "demands", ["offer_id"], name: "index_demands_on_offer_id", using: :btree
+  add_index "demands", ["term_id"], name: "index_demands_on_term_id", using: :btree
+
   create_table "instructors", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "offers", force: :cascade do |t|
+    t.integer  "assignation_id"
+    t.integer  "status",         default: 0
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "offers", ["assignation_id"], name: "index_offers_on_assignation_id", using: :btree
+  add_index "offers", ["status"], name: "index_offers_on_status", using: :btree
 
   create_table "roles", force: :cascade do |t|
     t.string "name"
@@ -108,6 +126,9 @@ ActiveRecord::Schema.define(version: 20150423212250) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
+  add_foreign_key "demands", "offers"
+  add_foreign_key "demands", "terms"
+  add_foreign_key "offers", "assignations"
   add_foreign_key "schedules", "users"
   add_foreign_key "user_roles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,21 @@ ActiveRecord::Schema.define(version: 20150423212250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string   "namespace"
+    t.text     "body"
+    t.string   "resource_id",   null: false
+    t.string   "resource_type", null: false
+    t.integer  "author_id"
+    t.string   "author_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+  add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+  add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+
   create_table "assignations", force: :cascade do |t|
     t.integer  "schedule_id"
     t.integer  "term_id"

--- a/lib/assets/javascripts/active_admin_datepicker_init.js.coffee
+++ b/lib/assets/javascripts/active_admin_datepicker_init.js.coffee
@@ -1,0 +1,7 @@
+$(document).ready ->
+  $("input.datetime_picker").datetimepicker
+    format: "Y-m-d H:i"
+    step: 5
+    dayOfWeekStart: 1
+    minTime: "8:00"
+    maxTime: "22:00"

--- a/spec/models/demand_spec.rb
+++ b/spec/models/demand_spec.rb
@@ -1,0 +1,11 @@
+describe Demand do
+  describe "associations" do
+    it { should belong_to :offer }
+    it { should belong_to :term }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :offer }
+    it { should validate_presence_of :term }
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -1,0 +1,11 @@
+describe Offer do
+  describe "associations" do
+    it { should belong_to :assignation }
+    it { should have_many :demands }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :assignation }
+    it { should validate_presence_of :demands }
+  end
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,11 @@
+describe Role do
+  describe "associations" do
+    it { should have_many(:user_roles) }
+    it { should have_many(:users).through(:user_roles) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :name }
+    it { should validate_uniqueness_of :name }
+  end
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -10,6 +10,8 @@ describe Term do
   end
 
   describe "validations" do
+    subject { Fabricate.build(:term) }
+
     it { should validate_presence_of :starts_at }
     it { should validate_presence_of :ends_at }
 
@@ -21,8 +23,7 @@ describe Term do
     it { should validate_uniqueness_of(:starts_at).scoped_to(:subject_id, :instructor_id) }
 
     it "validates date range correctness" do
-      subject { Fabricate.build(:term, starts_at: Time.now, ends_at: Time.now - 1.hour) }
-
+      subject.ends_at = subject.starts_at - 1.hour
       expect(subject).to_not be_valid
     end
   end

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -1,0 +1,11 @@
+describe UserRole do
+  describe "associations" do
+    it { should belong_to :user }
+    it { should belong_to :role }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :user }
+    it { should validate_presence_of :role }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,6 @@
 describe User do
-  subject do
-    Fabricate.build :user,
-      username: "Fan",
-      email: "fan@example.com",
-      student_number: 258560,
-      password: "yay-safe"
-  end
+  let(:user) { Fabricate.build :user }
+  subject { user }
 
   describe "validations" do
     let(:valid_emails) { %w(michalb@tests.com michal.b@tests.extensive.com) }
@@ -34,5 +29,27 @@ describe User do
 
   describe "associations" do
     it { should have_many :schedules }
+    it { should have_many(:user_roles) }
+    it { should have_many(:roles).through(:user_roles) }
+  end
+
+  describe "#admin?" do
+    subject { user.admin? }
+
+    before do
+      allow(user).to receive(:roles).and_return roles
+    end
+
+    context "when user is admin" do
+      let(:roles) { [double(name: "Admin"), double(name: "Foreman")] }
+
+      it { should be_truthy }
+    end
+
+    context "when user is not admin" do
+      let(:roles) { [double(name: "Foreman")] }
+
+      it { should be_falsey }
+    end
   end
 end


### PR DESCRIPTION
- dodaje grupy użytkowników
- dodaje metodę `#admin?` do modelu usera, sprawdzając, czy należy do jakiejkolwiek grupy zawierającej słowo `Admin` w nazwie, np. `SuperAdmin` czy `Admin`
- zmienia typ `:starts_at` i `:ends_at` w modelu `Term` na `time` z `datetime`. Choć w bazie informacja jest zapisywana w tym samym formacie, jest inaczej traktowany przez Railsy i lepiej odpowiada danym które my tam zapisujemy
- dodaje panel ActiveAdmin
- dodaje gem Draper do dekorowania modeli
- dodaje widoki w panelu admina dla istniejących modeli
